### PR TITLE
Mueller/cleanup multi merge

### DIFF
--- a/Documentation/README-InstrumentDriverSpecsRepoOrg.md
+++ b/Documentation/README-InstrumentDriverSpecsRepoOrg.md
@@ -1,7 +1,0 @@
-# README Fragment
-
-This is just the table entry to go into the README.md document in the Documentation directory for this document.
-
-| file | Contents |
-| ---- | -------- |
-| InstrumentDriverSpecsRepoOrg.md | Describes the organization of this repository and how versions of specifications and shared components are managed |

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,8 +1,9 @@
 # README File for IVI Driver Documentation Directory
 
 This file describes the various documents in the *Documentation*
-directory of the *IviFoundation/IviDriver* repository.
+directory of the *IviFoundation/InstrumentDriverSpecs* repository.
 
 | Document    |  Content  |
 | --------    |  -------  |
 | [UsingStringsAsRepCapSelectors](./UsingStringsAsRepCapSelectors.md) | Contains a verified syntax for representing complex repeated capabilities including nested ranges of multiple repeated capabilities. |
+| [InstrumentDriverSpecsRepoOrg](./InstrumentDriverSpecsRepoOrg.md)   | Describes the organization of this repository and how versions of specifications and shared components are managed |

--- a/IviDriverCore/1.0/Spec/ExampleComplianceDocument.md
+++ b/IviDriverCore/1.0/Spec/ExampleComplianceDocument.md
@@ -1,6 +1,6 @@
 # Example IVI Driver Compliance Document
 
-This is the IVI Compliance document for the Keysight Technologies Q12120A instrument.
+This is the IVI Compliance document for the fictional Keysight Technologies Q12120A instrument.
 
 ## IVI Compliance Category
 


### PR DESCRIPTION
This merges a pair of  README files that were necessarily separated because of the multiple outstanding PRs.

It also corrects a typo in one of the spec example files that was apparent on review (that is, the fake compliance document read as if it were an actual instrument).